### PR TITLE
Updated RestSharp package from 106.6.7 to 112.1.0

### DIFF
--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
+	<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/OpenExchangeRatesSharp/OpenExchangeRatesSharp.csproj
+++ b/OpenExchangeRatesSharp/OpenExchangeRatesSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Title>OpenExchangeRates C# Wrapper</Title>
@@ -21,6 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.6.7" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
 </Project>

--- a/OpenExchangeRatesSharp/RateClient.cs
+++ b/OpenExchangeRatesSharp/RateClient.cs
@@ -37,7 +37,7 @@ namespace OpenExchangeRatesSharp
         /// <returns></returns>
         public RateResult GetLatest(string baseCurrencyCode = DefaultBaseCurrency, string[] symbols = null)
         {
-            var request = new RestRequest("latest.json", Method.GET);
+            var request = new RestRequest("latest.json", Method.Get);
             if (baseCurrencyCode != DefaultBaseCurrency)
                 request.AddQueryParameter("base", baseCurrencyCode);
             if (symbols != null)
@@ -54,13 +54,13 @@ namespace OpenExchangeRatesSharp
         /// <returns></returns>
         public ConversionResult Convert(string fromCurrency, string toCurrency, decimal value)
         {
-            var request = new RestRequest($"convert/{value}/{fromCurrency}/{toCurrency}", Method.GET);
+            var request = new RestRequest($"convert/{value}/{fromCurrency}/{toCurrency}", Method.Get);
             return Execute<ConversionResult>(request);
         }
 
         #endregion
 
-        private T Execute<T>(IRestRequest request) where T : new()
+        private T Execute<T>(RestRequest request) where T : new()
         {
             request.AddQueryParameter("app_id", ApiKey);
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Updated `RestSharp` package from `106.6.7` to `112.1.0` in `OpenExchangeRatesSharp.csproj`.
- Suppressed TFM support build warnings in `IntegrationTests.csproj` and `UnitTests.csproj`.
- Adjusted `RateClient.cs` to align with `RestSharp` API changes:
  - Replaced `Method.GET` with `Method.Get`.
  - Updated `Execute<T>` to accept `RestRequest` instead of `IRestRequest`.
- Noted unintended addition of BOM in `OpenExchangeRatesSharp.csproj`.