### PR TITLE
update GitHub action versions and NuGet packages, bump version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,9 @@
-name: .NET Core
+name: .NET
 
 on:
   push:
+    branches: [ master ]
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -10,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v5
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 8.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Publish OpenExchangeRatesSharp
-      uses: brandedoutcast/publish-nuget@v2.5.2
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: alirezanet/publish-nuget@v3.1.0
       with:
           PROJECT_FILE_PATH: OpenExchangeRatesSharp/OpenExchangeRatesSharp.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenExchangeRatesSharp/OpenExchangeRatesSharp.csproj
+++ b/OpenExchangeRatesSharp/OpenExchangeRatesSharp.csproj
@@ -5,7 +5,7 @@
     <Description>A simple C# wrapper over the [https://openexchangerates.org/](openexchangerates.org) API</Description>
     <Company>LukeWarrenDev</Company>
     <Authors>Luke Warren</Authors>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageId>OpenExchangeRatesSharp</PackageId>
     <PackageLicenseUrl>https://github.com/Lukejkw/OpenExchangeRatesSharp/blob/master/License.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Lukejkw/OpenExchangeRatesSharp/</PackageProjectUrl>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should resolve the build failure caused by outdated .NET Core 3.1.301 that prevented the recent library update from publishing.

- Updated GitHub Actions to use current versions (`checkout@v5`, `setup-dotnet@v5`, `alirezanet/publish-nuget@v3.1.0`) and changed `dotnet-version` to `8.0.x`
- The build workflow will also run now when a PR is created, but the package is only published when it's merged
- Changed test projects to .NET 8 and applied some package version updates
- Fixes: [No usable version of libssl was found error](https://github.com/Lukejkw/OpenExchangeRatesSharp/actions/runs/16013893074/job/45176809739)
- Updated project version to `1.0.3`